### PR TITLE
fix(api): Correct misleading error in knowledge endpoint

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -15,7 +15,8 @@ def get_knowledge_answer(req: Request, request_data: schemas.QuestionRequest):
     if knowledge_service is None:
         raise HTTPException(
             status_code=503,
-            detail="KnowledgeService is not available. Ensure OPENAI_API_KEY is set and vector store is built.",
+            detail="KnowledgeService is not available. This could be because the vector store has not been "
+                   "built yet, or the embedding model is misconfigured. Please check the application logs."
         )
 
     result = knowledge_service.answer_question(request_data.question)

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+pytest-mock

--- a/backend/tests/api/endpoints/test_knowledge.py
+++ b/backend/tests/api/endpoints/test_knowledge.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from app.main import app
+
+def test_get_knowledge_answer_service_unavailable(client: TestClient, monkeypatch):
+    """
+    Test the /knowledge/answer endpoint when the KnowledgeService is not available.
+    It should return a 503 error with the corrected, helpful message.
+    """
+    monkeypatch.setattr(app.state, "knowledge_service", None)
+
+    response = client.post("/api/knowledge/answer", json={"question": "What is the return policy?"})
+
+    assert response.status_code == 503
+    response_json = response.json()
+    assert "detail" in response_json
+    # Assert that the old, incorrect message is GONE
+    assert "OPENAI_API_KEY" not in response_json["detail"]
+    # Assert that the new, helpful message is present
+    assert "vector store has not been built" in response_json["detail"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi.testclient import TestClient
+
+# We need to import the app to create a TestClient.
+# This is now safe because we'll set a dummy API key before running pytest.
+from app.main import app
+
+@pytest.fixture(scope="module")
+def client():
+    """
+    Provides a test client for the FastAPI application.
+    """
+    with TestClient(app) as c:
+        yield c


### PR DESCRIPTION
The error message for an unavailable KnowledgeService incorrectly referenced OPENAI_API_KEY. This was misleading because the KnowledgeService uses a local embedding model and does not depend on OpenAI.

This change updates the error message to provide more accurate debugging guidance, pointing to the vector store or embedding model configuration as potential issues.

A new pytest test is added to verify the corrected error message. The test environment is configured with a new requirements-dev.txt and a conftest.py to provide a test client.